### PR TITLE
Use 422 response status code for validation errors

### DIFF
--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -155,7 +155,7 @@ class ApiController extends BaseController
     public function responseValidationFailed(string $message = 'Validation error.'): JsonResponse
     {
         return $this->setStatusCode(215)
-            ->setResponseCode(400)
+            ->setResponseCode(422)
             ->respondWithError($message);
     }
 


### PR DESCRIPTION
Sense  the exception has been updated to 422 reponse code this method was missing.

See: https://github.com/Napp/apicore/commit/ae6c41cb3709be08d28307fdf8ec4ed34793dd92