### PR TITLE
Feature/api transformer strict mode

### DIFF
--- a/src/Transformers/ApiTransformer.php
+++ b/src/Transformers/ApiTransformer.php
@@ -14,6 +14,14 @@ class ApiTransformer implements TransformerInterface
     protected $apiMapping = [];
 
     /**
+     * Strict mode removes keys that are
+     * not specified in api mapping array.
+     *
+     * @var bool
+     */
+    protected $strict = false;
+
+    /**
      * @param array|Model $apiMapping
      * @return void
      */
@@ -23,7 +31,7 @@ class ApiTransformer implements TransformerInterface
 
         if (true === $apiMapping instanceof Model && true === property_exists($apiMapping, 'apiMapping')) {
             $this->apiMapping = $apiMapping->apiMapping;
-        } elseif (true === is_array($apiMapping)) {
+        } elseif (true === \is_array($apiMapping)) {
             $this->apiMapping = $apiMapping;
         }
     }
@@ -36,7 +44,7 @@ class ApiTransformer implements TransformerInterface
     {
         $input = [];
 
-        $data = (true === is_array($data)) ? $data : $data->toArray();
+        $data = (true === \is_array($data)) ? $data : $data->toArray();
         foreach ($data as $key => $value) {
             $input[$this->findOriginalKey($key)] = $value;
         }
@@ -57,8 +65,11 @@ class ApiTransformer implements TransformerInterface
                 $output[] = $this->transformOutput($item);
             }
         } else {
-            $data = (true === is_array($data)) ? $data : $data->toArray();
+            $data = (true === \is_array($data)) ? $data : $data->toArray();
             foreach ($data as $key => $value) {
+                if (true === $this->strict && false === array_key_exists($key, $this->apiMapping)) {
+                    continue;
+                }
                 $output[$this->findNewKey($key)] = $this->convertValueType($key, $value);
             }
         }
@@ -73,7 +84,7 @@ class ApiTransformer implements TransformerInterface
     protected function findOriginalKey(string $newKey)
     {
         foreach ($this->apiMapping as $key => $value) {
-            if (true === in_array($newKey, $value)) {
+            if (true === \in_array($newKey, $value)) {
                 return $key;
             }
         }

--- a/tests/ApiTransformerTest.php
+++ b/tests/ApiTransformerTest.php
@@ -46,7 +46,31 @@ class ApiTransformerTest extends TestCase
         ];
         $transformedInput = $this->transformer->transformInput($input);
 
-        $this->assertArraySubset($expectedInput, $transformedInput);
+        $this->assertEquals($expectedInput, $transformedInput);
+    }
+
+    public function test_strict_output_transforming()
+    {
+        $reflection = new \ReflectionProperty(\get_class($this->transformer), 'strict');
+        $reflection->setAccessible(true);
+        $reflection->setValue($this->transformer, true);
+
+        $output = [
+            'id' => 1,
+            'name' => 'Wayne Industries',
+            'has_access' => 0,
+            'some_additional_field' => 'some_additional_value'
+        ];
+
+        $expectedOutput = [
+            'id' => 1,
+            'companyName' => 'Wayne Industries',
+            'hasAccess' => false,
+        ];
+
+        $transformedOutput = $this->transformer->transformOutput($output);
+        $this->assertEquals($expectedOutput, $transformedOutput);
+        $this->assertArrayNotHasKey('some_additional_field', $transformedOutput);
     }
 
     public function test_output_transforming()
@@ -65,9 +89,8 @@ class ApiTransformerTest extends TestCase
             'some_additional_field' => 'some_additional_value'
         ];
 
-
         $transformedOutput = $this->transformer->transformOutput($output);
 
-        $this->assertArraySubset($expectedOutput, $transformedOutput);
+        $this->assertEquals($expectedOutput, $transformedOutput);
     }
 }


### PR DESCRIPTION
Added strict mode for api transformer that gets rid of fields that are not defined in api mapping when transforming output
Test included