### PR TITLE
Extend transformer with primitive values

### DIFF
--- a/src/Transformers/ApiTransformer.php
+++ b/src/Transformers/ApiTransformer.php
@@ -123,7 +123,7 @@ class ApiTransformer implements TransformerInterface
             }
 
             if ('Nullable' === $method) {
-                if (true === empty($value)) {
+                if (true === empty($value) && false === \is_numeric($value)) {
                     return null;
                 }
 

--- a/src/Transformers/ApiTransformer.php
+++ b/src/Transformers/ApiTransformer.php
@@ -5,6 +5,7 @@ namespace Napp\Core\Api\Transformers;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 class ApiTransformer implements TransformerInterface
 {
@@ -116,19 +117,115 @@ class ApiTransformer implements TransformerInterface
             ? $this->apiMapping[$key]['dataType']
             : 'string';
 
-        switch ($type) {
-            case 'datetime':
-                return strtotime($value) > 0 ? date("c", strtotime($value)) : '';
-            case 'int':
-                return (int) $value;
-            case 'bool':
-                return (bool) $value;
-            case 'array':
-                return (array) $value;
-            case 'json':
-                return json_decode($value);
-            default:
+        foreach (static::normalizeType($type) as list($method, $parameters)) {
+            if (true === empty($method)) {
                 return $value;
+            }
+
+            if ('Nullable' === $method) {
+                if (true === empty($value)) {
+                    return null;
+                }
+
+                continue;
+            }
+
+            $method = "convert{$method}";
+
+            if (false === method_exists(TransformerMethods::class, $method)) {
+                return $value;
+            }
+
+            return TransformerMethods::$method($value, $parameters);
+        }
+    }
+
+    protected static function parseStringDataType($type): array
+    {
+        $parameters = [];
+
+        // The format for specifying validation rules and parameters follows an
+        // easy {rule}:{parameters} formatting convention. For instance the
+        // rule "Max:3" states that the value may only be three letters.
+        if (mb_strpos($type, ':') !== false) {
+            list($dataType, $parameter) = explode(':', $type, 2);
+
+            $parameters = static::parseParameters($parameter);
+        }
+
+        $dataType = static::normalizeDataType(trim($dataType ?? $type));
+
+        return [Str::studly($dataType), $parameters ?? []];
+    }
+
+    /**
+     * Parse a parameter list.
+     *
+     * @param  string  $parameter
+     * @return array
+     */
+    protected static function parseParameters($parameter): array
+    {
+        return str_getcsv($parameter);
+    }
+
+    protected static function parseManyDataTypes($type): array
+    {
+        $parsed = [];
+
+        $dataTypes = explode('|', $type);
+
+        foreach ($dataTypes as $dataType) {
+            $parsed[] = static::parseStringDataType(trim($dataType));
+        }
+
+        return $parsed;
+    }
+
+    protected static function normalizeType($type): array
+    {
+        if (false !== mb_strpos($type, '|')) {
+            return self::normalizeNullable(
+                static::parseManyDataTypes($type)
+            );
+        }
+
+        return [static::parseStringDataType($type)];
+    }
+
+    /**
+     * @param $type
+     * @return bool
+     */
+    protected static function hasParameters($type): bool
+    {
+        return false !== mb_strpos($type, ':');
+    }
+
+    /**
+     * @param $dataTypes
+     * @return array
+     */
+    protected static function normalizeNullable($dataTypes): array
+    {
+        if (isset($dataTypes[1][0]) && $dataTypes[1][0] === 'Nullable') {
+            return array_reverse($dataTypes);
+        }
+
+        return $dataTypes;
+    }
+
+    protected static function normalizeDataType($type): string
+    {
+        switch ($type) {
+            case 'int':
+                return 'integer';
+            case 'bool':
+                return 'boolean';
+            case 'date':
+                return 'datetime';
+            default:
+                return $type;
         }
     }
 }

--- a/src/Transformers/ApiTransformer.php
+++ b/src/Transformers/ApiTransformer.php
@@ -144,9 +144,9 @@ class ApiTransformer implements TransformerInterface
     {
         $parameters = [];
 
-        // The format for specifying validation rules and parameters follows an
-        // easy {rule}:{parameters} formatting convention. For instance the
-        // rule "Max:3" states that the value may only be three letters.
+        // The format for transforming data-types and parameters follows an
+        // easy {data-type}:{parameters} formatting convention. For instance the
+        // data-type "float:3" states that the value will be converted to a float with 3 decimals.
         if (mb_strpos($type, ':') !== false) {
             list($dataType, $parameter) = explode(':', $type, 2);
 
@@ -190,7 +190,7 @@ class ApiTransformer implements TransformerInterface
             );
         }
 
-        return [static::parseStringDataType($type)];
+        return [static::parseStringDataType(trim($type))];
     }
 
     /**

--- a/src/Transformers/TransformerMethods.php
+++ b/src/Transformers/TransformerMethods.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Napp\Core\Api\Transformers;
+
+class TransformerMethods
+{
+    public static function convertJson($value)
+    {
+        return json_decode($value);
+    }
+
+    public static function convertInteger($value): int
+    {
+        return (int) $value;
+    }
+
+    public static function convertString($value): string
+    {
+        return (string) $value;
+    }
+
+    public static function convertFloat($value, $parameters): float
+    {
+        if (isset($parameters[0])) {
+            return round($value, $parameters[0], PHP_ROUND_HALF_UP);
+        }
+
+        return (float) $value;
+    }
+
+    public static function convertBoolean($value): bool
+    {
+        return (bool) $value;
+    }
+
+    public static function convertArray($value): array
+    {
+        return (array) $value;
+    }
+
+    public static function convertDatetime($value): string
+    {
+        return strtotime($value) > 0 ? date('c', strtotime($value)) : '';
+    }
+}

--- a/tests/ApiTransformerTest.php
+++ b/tests/ApiTransformerTest.php
@@ -115,7 +115,7 @@ class ApiTransformerTest extends TestCase
         ];
 
         $expectedOutput = [
-            'price' => null
+            'price' => 0
         ];
 
         $this->assertSame($expectedOutput, $this->transformer->transformOutput($input));
@@ -142,11 +142,11 @@ class ApiTransformerTest extends TestCase
         ]);
 
         $input = [
-            'price' => '100.54'
+            'price' => '100.5542'
         ];
 
         $expectedOutput = [
-            'price' => 100.54
+            'price' => 100.55
         ];
 
         $this->assertSame($expectedOutput, $this->transformer->transformOutput($input));

--- a/tests/ApiTransformerTest.php
+++ b/tests/ApiTransformerTest.php
@@ -93,4 +93,62 @@ class ApiTransformerTest extends TestCase
 
         $this->assertEquals($expectedOutput, $transformedOutput);
     }
+
+    public function test_the_datatype_is_nullable()
+    {
+        $this->transformer->setApiMapping([
+            'price' => ['newName' => 'price', 'dataType' => 'nullable|int']
+        ]);
+
+        $input = [
+            'price' => '100'
+        ];
+
+        $expectedOutput = [
+            'price' => 100
+        ];
+
+        $this->assertSame($expectedOutput, $this->transformer->transformOutput($input));
+
+        $input = [
+            'price' => 0
+        ];
+
+        $expectedOutput = [
+            'price' => null
+        ];
+
+        $this->assertSame($expectedOutput, $this->transformer->transformOutput($input));
+
+        $this->transformer->setApiMapping([
+            'description' => ['newName' => 'description', 'dataType' => 'array|nullable']
+        ]);
+
+        $input = [
+            'description' => []
+        ];
+
+        $expectedOutput = [
+            'description' => null
+        ];
+
+        $this->assertSame($expectedOutput, $this->transformer->transformOutput($input));
+    }
+
+    public function test_arguments_can_be_passed_to_the_datatype()
+    {
+        $this->transformer->setApiMapping([
+            'price' => ['newName' => 'price', 'dataType' => 'float:2']
+        ]);
+
+        $input = [
+            'price' => '100.54'
+        ];
+
+        $expectedOutput = [
+            'price' => 100.54
+        ];
+
+        $this->assertSame($expectedOutput, $this->transformer->transformOutput($input));
+    }
 }


### PR DESCRIPTION
The transformer can now take float data-types with an extra parameter for decimal precision.

I have also allowed for a new type **nullables**

To use nullables you need another primitive type along with it.

So for instance if I want my array to be null if it's empty i'll write: **nullable|array** or **array|nullable** if the value is empty it will be converted to null if it's not it will be an array.

