### PR TITLE
Feature/fixes for transforming relationships

### DIFF
--- a/src/Transformers/ApiTransformer.php
+++ b/src/Transformers/ApiTransformer.php
@@ -131,25 +131,27 @@ class ApiTransformer implements TransformerInterface
                 continue;
             }
 
+            $outputKey = $this->findNewKey($relationshipName);
+
             if (null === $relationship) {
-                $output[$relationshipName] = $this->convertValueType($relationshipName, null);
+                $output[$outputKey] = $this->convertValueType($relationshipName, null);
             } elseif (true === $relationship instanceof Collection) {
                 if ($relationship->isEmpty()) {
-                    $output[$relationshipName] = $this->convertValueType($relationshipName, null);
+                    $output[$outputKey] = $this->convertValueType($relationshipName, null);
                     continue;
                 }
 
                 if ($this->isTransformAware($relationship->first())) {
-                    $output[$relationshipName] = $relationship->first()->getTransformer()->transformOutput($relationship);
+                    $output[$outputKey] = $relationship->first()->getTransformer()->transformOutput($relationship);
                 } else {
-                    $output[$relationshipName] = $relationship->toArray();
+                    $output[$outputKey] = $relationship->toArray();
                 }
             } else {
                 // model
                 if ($this->isTransformAware($relationship)) {
-                    $output[$relationshipName] = $relationship->getTransformer()->transformOutput($relationship);
+                    $output[$outputKey] = $relationship->getTransformer()->transformOutput($relationship);
                 } else {
-                    $output[$relationshipName] = $relationship->getAttributes();
+                    $output[$outputKey] = $relationship->getAttributes();
                 }
             }
         }

--- a/src/Transformers/ApiTransformer.php
+++ b/src/Transformers/ApiTransformer.php
@@ -127,12 +127,15 @@ class ApiTransformer implements TransformerInterface
         /** @var Model $data */
         $relationships = $data->getRelations();
         foreach ($relationships as $relationshipName => $relationship) {
-            if (null === $relationship) {
-                $output[$relationshipName] = $this->isMapped($relationshipName) ? $this->convertValueType($relationshipName, null) : null;
+            if (true === $this->strict && ! $this->isMapped($relationshipName)) {
+                continue;
             }
-            else if (true === $relationship instanceof Collection) {
+
+            if (null === $relationship) {
+                $output[$relationshipName] = $this->convertValueType($relationshipName, null);
+            } elseif (true === $relationship instanceof Collection) {
                 if ($relationship->isEmpty()) {
-                    $output[$relationshipName] = $this->isMapped($relationshipName) ? $this->convertValueType($relationshipName, null) : null;
+                    $output[$relationshipName] = $this->convertValueType($relationshipName, null);
                     continue;
                 }
 
@@ -141,8 +144,7 @@ class ApiTransformer implements TransformerInterface
                 } else {
                     $output[$relationshipName] = $relationship->toArray();
                 }
-            }
-            else {
+            } else {
                 // model
                 if ($this->isTransformAware($relationship)) {
                     $output[$relationshipName] = $relationship->getTransformer()->transformOutput($relationship);

--- a/tests/ApiTransformerTest.php
+++ b/tests/ApiTransformerTest.php
@@ -5,6 +5,7 @@ namespace Napp\Core\Api\Tests\Unit;
 use Napp\Core\Api\Tests\Models\Category;
 use Napp\Core\Api\Tests\Models\Post;
 use Napp\Core\Api\Tests\Models\Product;
+use Napp\Core\Api\Tests\Transformers\CategoryStrictTransformer;
 use Napp\Core\Api\Tests\Transformers\PostTransformer;
 use Napp\Core\Api\Tests\Transformers\ProductTransformer;
 use Napp\Core\Api\Transformers\ApiTransformer;
@@ -313,5 +314,17 @@ class ApiTransformerTest extends TestCase
         $this->assertArrayNotHasKey('updated_at', $result);
         $this->assertEquals(3, count($result['tags']));
         $this->assertNull($result['otherTags']);
+    }
+
+    public function test_transform_model_relations_is_exluded_if_not_found_in_transform_map_and_strict_mode_is_enabled()
+    {
+        /** @var Category $category */
+        $category = Category::create(['title' => 'Electronics']);
+        $category->products()->create(['name' => 'iPhone', 'price'=> 100.0]);
+        $category->load('products');
+
+        $result = (new CategoryStrictTransformer())->transformOutput($category);
+
+        $this->assertArrayNotHasKey('products', $result);
     }
 }

--- a/tests/ApiTransformerTest.php
+++ b/tests/ApiTransformerTest.php
@@ -6,6 +6,7 @@ use Napp\Core\Api\Tests\Models\Category;
 use Napp\Core\Api\Tests\Models\Post;
 use Napp\Core\Api\Tests\Models\Product;
 use Napp\Core\Api\Tests\Transformers\CategoryStrictTransformer;
+use Napp\Core\Api\Tests\Transformers\CategoryTransformerWithDifferentOutputKey;
 use Napp\Core\Api\Tests\Transformers\PostTransformer;
 use Napp\Core\Api\Tests\Transformers\ProductTransformer;
 use Napp\Core\Api\Transformers\ApiTransformer;
@@ -323,8 +324,21 @@ class ApiTransformerTest extends TestCase
         $category->products()->create(['name' => 'iPhone', 'price'=> 100.0]);
         $category->load('products');
 
-        $result = (new CategoryStrictTransformer())->transformOutput($category);
+        $result = (new CategoryStrictTransformer)->transformOutput($category);
 
         $this->assertArrayNotHasKey('products', $result);
+    }
+
+    public function test_transform_model_relations_with_different_output_key()
+    {
+        /** @var Category $category */
+        $category = Category::create(['title' => 'Electronics']);
+        $category->products()->create(['name' => 'iPhone', 'price'=> 100.0]);
+        $category->load('products');
+
+        $result = (new CategoryTransformerWithDifferentOutputKey)->transformOutput($category);
+
+        $this->assertArrayNotHasKey('products', $result);
+        $this->assertArrayHasKey('indexes', $result);
     }
 }

--- a/tests/Transformers/CategoryStrictTransformer.php
+++ b/tests/Transformers/CategoryStrictTransformer.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Napp\Core\Api\Tests\Transformers;
+
+use Napp\Core\Api\Transformers\ApiTransformer;
+
+class CategoryStrictTransformer extends ApiTransformer
+{
+    protected $strict = true;
+
+    public function __construct()
+    {
+        $this->setApiMapping([
+            'id'         => ['newName' => 'id',         'dataType' => 'int'],
+        ]);
+    }
+}

--- a/tests/Transformers/CategoryTransformer.php
+++ b/tests/Transformers/CategoryTransformer.php
@@ -11,7 +11,6 @@ use Napp\Core\Api\Transformers\ApiTransformer;
  */
 class CategoryTransformer extends ApiTransformer
 {
-    protected $strict = true;
     /**
      * @param Category $category
      */

--- a/tests/Transformers/CategoryTransformerWithDifferentOutputKey.php
+++ b/tests/Transformers/CategoryTransformerWithDifferentOutputKey.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Napp\Core\Api\Tests\Transformers;
+
+use Napp\Core\Api\Transformers\ApiTransformer;
+
+class CategoryTransformerWithDifferentOutputKey extends ApiTransformer
+{
+    public function __construct()
+    {
+        $this->setApiMapping([
+            'id'         => ['newName' => 'id',         'dataType' => 'int'],
+            'title'      => ['newName' => 'name',       'dataType' => 'string'],
+            'products'   => ['newName' => 'indexes',     'dataType' => 'array'],
+        ]);
+    }
+}

--- a/tests/Transformers/PostTransformer.php
+++ b/tests/Transformers/PostTransformer.php
@@ -11,7 +11,7 @@ use Napp\Core\Api\Transformers\ApiTransformer;
  */
 class PostTransformer extends ApiTransformer
 {
-    protected $strict = false;
+
     /**
      * @param Post $post
      */

--- a/tests/Transformers/ProductTransformer.php
+++ b/tests/Transformers/ProductTransformer.php
@@ -11,7 +11,7 @@ use Napp\Core\Api\Transformers\ApiTransformer;
  */
 class ProductTransformer extends ApiTransformer
 {
-    protected $strict = true;
+
     /**
      * @param Product $product
      */

--- a/tests/Transformers/VariantTransformer.php
+++ b/tests/Transformers/VariantTransformer.php
@@ -11,7 +11,7 @@ use Napp\Core\Api\Transformers\ApiTransformer;
  */
 class VariantTransformer extends ApiTransformer
 {
-    protected $strict = true;
+
     /**
      * @param Variant $variant
      */


### PR DESCRIPTION
- Make transforming relationships adhere to transformer strict mode (it was previously still included even tho the transfomer was in strict mode) which is inconsitent with the way we transform attributes.

- Allow the output key of a relationship to be transformed
